### PR TITLE
Add str() around content length calculation

### DIFF
--- a/ci-cd-codepipeline.cfn.yml
+++ b/ci-cd-codepipeline.cfn.yml
@@ -155,7 +155,7 @@ Resources:
               response['Data'] = {"Message": "Resource creation failed"}
 
             response_body = json.dumps(response)
-            headers = {'content-type': '', "content-length": len(response_body) }
+            headers = {'content-type': '', "content-length": str(len(response_body)) }
             put_response = requests.put(event['ResponseURL'], headers=headers, data=response_body)
             return response
 


### PR DESCRIPTION
This fixers an issue that took a ferw hours to trobuleshoot. Apparently the headers dict really, really needs to str() the response_body's len()  calculation.